### PR TITLE
Update secret-tokens.yaml to handle secrets conditionally

### DIFF
--- a/charts/twentycrm/Chart.yaml
+++ b/charts/twentycrm/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for https://github.com/twentyhq/twenty
 name: twentycrm
-version: 0.2.0
+version: 0.2.1

--- a/charts/twentycrm/templates/secret-tokens.yaml
+++ b/charts/twentycrm/templates/secret-tokens.yaml
@@ -11,9 +11,17 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
+{{- if .Values.secrets }}
   ACCESS_TOKEN_SECRET: {{ default (randAlphaNum 32) .Values.secrets.accessToken | b64enc | quote }}
   LOGIN_TOKEN_SECRET: {{ default (randAlphaNum 32) .Values.secrets.loginToken | b64enc | quote }}
   REFRESH_TOKEN_SECRET: {{ default (randAlphaNum 32) .Values.secrets.refreshToken | b64enc | quote }}
   FILE_TOKEN_SECRET: {{ default (randAlphaNum 32) .Values.secrets.fileToken | b64enc | quote }}
   APP_SECRET: {{ default (randAlphaNum 32) .Values.secrets.appSecret | b64enc | quote }}
+{{- else }}
+  ACCESS_TOKEN_SECRET: {{ randAlphaNum 32 | b64enc | quote }}
+  LOGIN_TOKEN_SECRET: {{ randAlphaNum 32 | b64enc | quote }}
+  REFRESH_TOKEN_SECRET: {{ randAlphaNum 32 | b64enc | quote }}
+  FILE_TOKEN_SECRET: {{ randAlphaNum 32 | b64enc | quote }}
+  APP_SECRET: {{ randAlphaNum 32 | b64enc | quote }}
+{{- end }}
 


### PR DESCRIPTION
Add conditional logic to set secret tokens based on values.

When installing on Rancher RKE2, it fails without this fix. The install will complain the value of secrets is `nil` (even when adding them in values.yaml).

My fix just adds another check for empty values.